### PR TITLE
 feat: make call_leg_id deprecated

### DIFF
--- a/references/webhooks/webhooks/base/webhook.v1.yaml
+++ b/references/webhooks/webhooks/base/webhook.v1.yaml
@@ -58,6 +58,7 @@ properties:
     description: |-
       Describes a unique identifier for the leg of a call that has multiple legs.
       For example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id
+    deprecated: true
   call_id:
     type: string
     minLength: 32

--- a/specs/webhooks.v1.json
+++ b/specs/webhooks.v1.json
@@ -59,7 +59,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -166,7 +167,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -254,7 +256,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -360,7 +363,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -448,7 +452,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -559,7 +564,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -655,7 +661,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -747,7 +754,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -862,7 +870,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -982,7 +991,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -1074,7 +1084,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -1180,7 +1191,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -1272,7 +1284,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -1367,7 +1380,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -1481,7 +1495,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -1574,7 +1589,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -1667,7 +1683,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -1761,7 +1778,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -1868,7 +1886,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -1960,7 +1979,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -2159,7 +2179,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -2278,7 +2299,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -2369,7 +2391,8 @@
             "minLength": 32,
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
-            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id"
+            "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
+			"deprecated": true
           },
           "call_id": {
             "type": "string",

--- a/specs/webhooks.v1.json
+++ b/specs/webhooks.v1.json
@@ -60,7 +60,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -168,7 +168,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -257,7 +257,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -364,7 +364,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -453,7 +453,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -565,7 +565,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -662,7 +662,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -755,7 +755,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -871,7 +871,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -992,7 +992,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -1085,7 +1085,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -1192,7 +1192,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -1285,7 +1285,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -1381,7 +1381,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -1496,7 +1496,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -1590,7 +1590,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -1684,7 +1684,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -1779,7 +1779,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -1887,7 +1887,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -1980,7 +1980,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -2180,7 +2180,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -2300,7 +2300,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",
@@ -2392,7 +2392,7 @@
             "pattern": "/^[0-9a-f]{32}$/gm",
             "maxLength": 32,
             "description": "Describes a unique identifier for the leg of a call that has multiple legs.\nFor example, if a single call is answered, put on hold, and then transferred via consultative transfer to another Team Member, each leg of the call will have a unique call_leg_id, but  a common call_id",
-			"deprecated": true
+            "deprecated": true
           },
           "call_id": {
             "type": "string",


### PR DESCRIPTION
We won't send `call_leg_id` in webhook after CallStateService release