### PR TITLE
add hold_duration for call_resume

### DIFF
--- a/references/webhooks/webhooks/base/hold-duration.v1.yaml
+++ b/references/webhooks/webhooks/base/hold-duration.v1.yaml
@@ -1,0 +1,6 @@
+description:
+type: object
+properties:
+  duration:
+    type: number
+    description: Length of time in seconds from the last hold event

--- a/references/webhooks/webhooks/call_resume.v1.yaml
+++ b/references/webhooks/webhooks/call_resume.v1.yaml
@@ -3,6 +3,7 @@ allOf:
   - $ref: ./base/user.v1.yaml
   - $ref: ./base/reason-resume.v1.yaml
   - $ref: ./base/c2c-info.v1.yaml
+  - $ref: ./base/hold-duration.v1.yaml
   - properties:
       event:
         type: string
@@ -28,6 +29,7 @@ examples:
       call_leg_id: c461419d34b1e66fb7ec5e15e0dc5202
       call_id: 818787cc58e3043c4b4721ed0c157735
       call_source: normal
+      hold_duration: 10
   click2call example:
     value:
       id: 497f6eca-6276-4993-bfeb-53cbbbba6f08


### PR DESCRIPTION
Example
```
{
  "id": "4f21aa09-8c85-4da7-a4e9-60f3d6e85d41",
  "event": "call_resume",
  "timestamp": "2021-08-17T13:07:10.59Z",
  "direction": "inbound",
  "user": {
    "id": 161973,
    "name": "dmitry 22",
    "account_id": 348824
  },
  "user_name": "dmitry 22",
  "reason": "resumer",
  "originating_number": "201",
  "dialed_number": "202",
  "call_id": "9a4dc27752e9f3e900e4745108f199ee",
  "call_source": "normal",
  "hold_duration": 16
}
```

Merge after unite Sept release. 